### PR TITLE
Remove depricated validate_re

### DIFF
--- a/manifests/p.pp
+++ b/manifests/p.pp
@@ -30,7 +30,7 @@ define mkdir::p (
   if ! $declare_file {
 
     if $mode {
-      validate_re($mode, '^[0-9]{4}$',
+      validate_legacy(String, 'validate_re', $mode, '^[0-9]{4}$',
         'mkdirp: Must give $mode as 4-digit-string')
       $threedigitmode = inline_template('<%= @mode[1..-1] if @mode[0] == "0" %>')
       exec { "${use_title}_chmod__${mode}":


### PR DESCRIPTION
`validate_re` has been deprecated as it is now covered by native Puppet data types and thus was removed from the latest `stdlib` [9.0.0](https://forge.puppet.com/modules/puppetlabs/stdlib/9.0.0/changelog#changed) causing a `Evaluation Error: Unknown function: 'validate_re'` error.